### PR TITLE
商品一覧表示機能タスクのレビュー依頼

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   
   def index
+    @items=Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,38 +127,39 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+    <% if @items.present? %>
+      <%# 商品が存在する場合 %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
+            <%# 商品が売れていればsold outを表示しましょう ※商品購入機能実装後に実装予定%>
+            <%# if  %>
+              <%#div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+            <%# end %>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.item_name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.item_price %>円<br><%= item.shipping_fee_status.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
+      <%# //商品が存在する場合 %>
+    <% else %>
+      <%# 商品が存在しない場合(サンプル画像を表示) %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +177,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# //商品が存在しない場合 %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品一覧表示機能作成

# Why
indexに商品の一覧を表示するため

実装条件「売却済みの商品は、画像上に「sold out」の文字が表示されること。」について、商品購入機能実装後に実装予定です。
 商品のデータがない場合は、ダミー商品が表示されている動画↓
https://gyazo.com/c9bf3713e3781c922f3bd483b8551306

 商品のデータがある場合は、商品が一覧で表示されている動画(実行前後の画像を追加で添付)↓
https://gyazo.com/d9a0321ea54af33fb11a84554d5e9167
https://gyazo.com/8bf8fa44034e5e423ecdeba0c7188317
https://gyazo.com/bae0a6e8b76abb2b10af39b09cda20d9